### PR TITLE
在输出文件大小的时候使用 filesize 库使得文件大小看起来更方便

### DIFF
--- a/bin/createTree.js
+++ b/bin/createTree.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs')
 const path = require('path')
+const filesize = require('filesize')
 
 const argv = require('yargs')
   .version()
@@ -21,7 +22,7 @@ let currentDir = '.'
 // 当前目录名称
 let currentDirName = path.basename(process.cwd())
 // 排除文件夹,默认把node_modules排除在遍历之外
-let excludeDir = 'node_modules'
+let excludeDir = /node_modules/
 // 设置各个标识
 let aFlag, dFlag, DFlag, fFlag, sFlag, tFlag, mFlag
 
@@ -51,7 +52,7 @@ if (argv.m) {
 if (argv.I) {
   //  /abc/i
   let oriReg = argv.I
-  if (/^\/.*\/[gimsuy]/.test(oriReg)) {
+  if (/^\/.*\/[gimsuy]*/.test(oriReg)) {
     let lastIndexOf = oriReg.lastIndexOf('/')
     let regStr = mFlag ? oriReg.slice(1, lastIndexOf) : oriReg.slice(1, lastIndexOf) + '|node_modules'
     excludeDir = new RegExp(regStr, oriReg.slice(lastIndexOf + 1))
@@ -207,7 +208,8 @@ function getRelativeFile(result) {
 // 显示文件的大小
 function getSizeFile(result) {
   result.forEach(function (item, index, arr) {
-    item.name = `[${(''+item.size).padStart(8)}]` + item.name
+//    item.name = `[${(''+item.size).padStart(8)}]` + item.name
+    item.name = `[${filesize(item.size).padStart(8)}]` + item.name
     if (item.type == "dir") {
       getSizeFile(item.children)
     }

--- a/package.json
+++ b/package.json
@@ -16,10 +16,20 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": ["tree", "directory", "yargs", "files", "directories", "tree-like"],
+  "keywords": [
+    "tree",
+    "directory",
+    "yargs",
+    "files",
+    "directories",
+    "tree-like"
+  ],
   "author": "stephen guo <1159468968@qq.com>",
   "license": "MIT",
   "dependencies": {
     "yargs": "^12.0.5"
+  },
+  "devDependencies": {
+    "filesize": "^4.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,9 +27,7 @@
   "author": "stephen guo <1159468968@qq.com>",
   "license": "MIT",
   "dependencies": {
-    "yargs": "^12.0.5"
-  },
-  "devDependencies": {
+    "yargs": "^12.0.5",
     "filesize": "^4.1.2"
   }
 }


### PR DESCRIPTION
真的如你所说，windows 下的 `tree` 是从颈部开始截肢的。

这个小工具带给我方便，谢谢。

Linux 下的 `tree` 输出文件大小时可以使用 `-h` 让输出不只是显示字节数，所以就找了一个 node 下 star 数最多的库集成进去了。

你看这样直接改好吗？还是再加一个 `-h` 参数更好些？